### PR TITLE
Fix transaction queue memory leak

### DIFF
--- a/src/y-mongodb.js
+++ b/src/y-mongodb.js
@@ -63,8 +63,9 @@ export class MongodbPersistence {
 			}
 
 			const currTr = this.tr[docName];
+			let nextTr = null;
 
-			this.tr[docName] = (async () => {
+			nextTr = (async () => {
 				await currTr;
 
 				let res = /** @type {any} */ (null);
@@ -73,8 +74,17 @@ export class MongodbPersistence {
 				} catch (err) {
 					console.warn('Error during saving transaction', err);
 				}
+
+				// once the last transaction for a given docName resolves, remove it from the queue
+				if (this.tr[docName] === nextTr) {
+					delete this.tr[docName];
+				}
+
 				return res;
 			})();
+
+			this.tr[docName] = nextTr
+
 			return this.tr[docName];
 		};
 	}


### PR DESCRIPTION
In the current implementation, promises are never cleared from the transaction queue (`this.tr`). This results in the memory usage steadily growing for each new Doc that is synced.

This PR removes the last transaction for a given Doc from the queue once it completes.