### PR TITLE
fix issue which causes crash in production due to not properly concatenating buffers

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -114,7 +114,7 @@ const _convertMongoUpdates = (docs) => {
 					break;
 				}
 			}
-			updates.push(...parts);
+			updates.push(Buffer.concat(parts));
 		}
 	}
 	return updates;

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,6 +119,8 @@ const _convertMongoUpdates = (docs) => {
 				}
 			}
 			updates.push(Buffer.concat(parts));
+			// set i to j - 1 because we already processed all parts
+			i = j - 1;
 		}
 	}
 	return updates;

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,7 +84,11 @@ export const _getMongoBulkData = (db, query, opts) => db.readAsCursor(query, opt
 export const flushDB = (db) => db.flush();
 
 /**
- * Convert the mongo document array to an array of values (as buffers)
+ *
+ * This function converts MongoDB updates to a buffer that can be processed by the application.
+ * It handles both complete documents and large documents that have been split into smaller 'parts' due to MongoDB's size limit.
+ * For split documents, it collects all the parts and merges them together.
+ * It assumes that the parts of a split document are ordered and located exactly after the document with part number 1.
  *
  * @param {any[]} docs
  * @return {Buffer[]}
@@ -119,6 +123,7 @@ const _convertMongoUpdates = (docs) => {
 	}
 	return updates;
 };
+
 /**
  * Get all document updates for a specific document.
  *

--- a/tests/generateLargeText.js
+++ b/tests/generateLargeText.js
@@ -1,0 +1,11 @@
+function generateLargeText(sizeInMb) {
+	const sizeInBytes = sizeInMb * 1024 * 1024;
+	const numberOfChars = Math.floor(sizeInBytes / 2); // JavaScript uses UTF-16 encoding, which uses 2 bytes per character
+	let largeText = '';
+	for (let i = 0; i < numberOfChars; i++) {
+		largeText += 'a';
+	}
+	return largeText;
+}
+
+module.exports = generateLargeText;


### PR DESCRIPTION
Impacts by anyone using v0.1.9

fixes: https://github.com/MaxNoetzold/y-mongodb-provider/issues/15

this is the bare minimum fix for this issue it might be nice to rework this whole function as it would gain huge benefit from not looping over the whole array of updates for every part it finds. 