### PR TITLE
Improves JSDocs & Rename mongo-adapter.js functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,13 @@ We welcome contributions! Please follow these steps to contribute:
 3. Make your changes and ensure tests pass: `npm test`.
 4. Submit a pull request with your changes.
 
-## Testing
+### Note about TypeScript
+
+We use type checking and type file generation with JSDoc comments. We do not use TypeScript in this project. We want to keep close to the original Yjs project, which is written in JavaScript. To read more about the decision to use JSDoc comments instead of the more conventional TypeScript, see [this issue](https://discuss.yjs.dev/t/why-are-yjs-types-writen-with-jsdocs-and-not-typescript/2668/3).
+
+If you are adding new functionality, please ensure that you add JSDoc comments to your code.
+
+### Testing
 
 To run the test suite, use the following command:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 				"eslint": "^8.57.0",
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-config-prettier": "^9.1.0",
-				"eslint-plugin-import": "^2.29.1",
 				"eslint-plugin-prettier": "^5.1.3",
 				"jest": "^29.7.0",
 				"mongodb-memory-server": "^9.3.0",
@@ -1549,7 +1548,8 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/node": {
 			"version": "20.14.2",
@@ -1743,6 +1743,7 @@
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
 			"integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -1762,6 +1763,7 @@
 			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
 			"integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -1781,6 +1783,7 @@
 			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.4.tgz",
 			"integrity": "sha512-hzvSHUshSpCflDR1QMUBLHGHP1VIEBegT4pix9H/Z92Xw3ySoy6c2qh7lJWTJnRJ8JCZ9bJNCgTyYaJGcJu6xQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.5",
 				"define-properties": "^1.2.1",
@@ -1800,6 +1803,7 @@
 			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
 			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -1818,6 +1822,7 @@
 			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
 			"integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -2501,7 +2506,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
 			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/es-define-property": {
 			"version": "1.0.0",
@@ -2543,6 +2549,7 @@
 			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
 			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"hasown": "^2.0.0"
 			}
@@ -2673,6 +2680,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
 			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^3.2.7",
 				"is-core-module": "^2.13.0",
@@ -2684,6 +2692,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
 			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -2693,6 +2702,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
 			"integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^3.2.7"
 			},
@@ -2710,6 +2720,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
 			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -2719,6 +2730,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
 			"integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"array-includes": "^3.1.7",
 				"array.prototype.findlastindex": "^1.2.3",
@@ -2750,6 +2762,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
 			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -2759,6 +2772,7 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -4665,6 +4679,7 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
 			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
 			},
@@ -4863,6 +4878,7 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -5189,6 +5205,7 @@
 			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
 			"integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -5206,6 +5223,7 @@
 			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.2.tgz",
 			"integrity": "sha512-bzBq58S+x+uo0VjurFT0UktpKHOZmv4/xePiOA1nbB9pMqpGK7rUPNgf+1YC+7mE+0HzhTMqNUuCqvKhj6FnBw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"array.prototype.filter": "^1.0.3",
 				"call-bind": "^1.0.5",
@@ -5219,6 +5237,7 @@
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
 			"integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.2.0",
@@ -6031,6 +6050,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -6179,6 +6199,7 @@
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
 			"integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/json5": "^0.0.29",
 				"json5": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
 	"name": "y-mongodb-provider",
-	"version": "0.1.9",
+	"version": "0.1.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "y-mongodb-provider",
-			"version": "0.1.9",
+			"version": "0.1.10",
 			"license": "MIT",
 			"dependencies": {
 				"lib0": "^0.2.94",
-				"mongodb": "^6.6.2"
+				"mongodb": "^6.7.0"
 			},
 			"devDependencies": {
 				"@types/jest": "^29.5.12",
-				"@types/node": "^20.12.12",
+				"@types/node": "^20.14.2",
 				"eslint": "^8.57.0",
 				"eslint-config-airbnb-base": "^15.0.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-import": "^2.29.1",
 				"eslint-plugin-prettier": "^5.1.3",
 				"jest": "^29.7.0",
-				"mongodb-memory-server": "^9.2.0",
-				"rollup": "^4.17.2",
+				"mongodb-memory-server": "^9.3.0",
+				"rollup": "^4.18.0",
 				"typescript": "^5.4.5",
 				"yjs": "^13.6.15"
 			},
 			"peerDependencies": {
-				"yjs": "^13.6.8"
+				"yjs": "^13.6.15"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -1224,9 +1224,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.17.2.tgz",
-			"integrity": "sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
+			"integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1237,9 +1237,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.17.2.tgz",
-			"integrity": "sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
+			"integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1250,9 +1250,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.17.2.tgz",
-			"integrity": "sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
+			"integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1263,9 +1263,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.17.2.tgz",
-			"integrity": "sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
+			"integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
 			"cpu": [
 				"x64"
 			],
@@ -1276,9 +1276,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.17.2.tgz",
-			"integrity": "sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
+			"integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
 			"cpu": [
 				"arm"
 			],
@@ -1289,9 +1289,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.17.2.tgz",
-			"integrity": "sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
+			"integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
 			"cpu": [
 				"arm"
 			],
@@ -1302,9 +1302,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.17.2.tgz",
-			"integrity": "sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
+			"integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1315,9 +1315,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.17.2.tgz",
-			"integrity": "sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
+			"integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1328,9 +1328,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.17.2.tgz",
-			"integrity": "sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
+			"integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1341,9 +1341,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.17.2.tgz",
-			"integrity": "sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
+			"integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1354,9 +1354,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.17.2.tgz",
-			"integrity": "sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
+			"integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1367,9 +1367,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.17.2.tgz",
-			"integrity": "sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
+			"integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
 			"cpu": [
 				"x64"
 			],
@@ -1380,9 +1380,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.17.2.tgz",
-			"integrity": "sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
+			"integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
 			"cpu": [
 				"x64"
 			],
@@ -1393,9 +1393,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.17.2.tgz",
-			"integrity": "sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
+			"integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1406,9 +1406,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.17.2.tgz",
-			"integrity": "sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
+			"integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1419,9 +1419,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.17.2.tgz",
-			"integrity": "sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
+			"integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
 			"cpu": [
 				"x64"
 			],
@@ -1552,9 +1552,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.12.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-			"integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+			"version": "20.14.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+			"integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -1997,9 +1997,9 @@
 			"dev": true
 		},
 		"node_modules/bare-events": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-			"integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.3.1.tgz",
+			"integrity": "sha512-sJnSOTVESURZ61XgEleqmP255T6zTYwHPwE4r6SssIh0U9/uDvfpdoJYpVUerJJZH2fueO+CdT8ZT+OC/7aZDA==",
 			"dev": true,
 			"optional": true
 		},
@@ -4868,9 +4868,9 @@
 			}
 		},
 		"node_modules/mongodb": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.6.2.tgz",
-			"integrity": "sha512-ZF9Ugo2JCG/GfR7DEb4ypfyJJyiKbg5qBYKRintebj8+DNS33CyGMkWbrS9lara+u+h+yEOGSRiLhFO/g1s1aw==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
+			"integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.1.5",
 				"bson": "^6.7.0",
@@ -4922,13 +4922,13 @@
 			}
 		},
 		"node_modules/mongodb-memory-server": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.2.0.tgz",
-			"integrity": "sha512-w/usKdYtby5EALERxmA0+et+D0brP0InH3a26shNDgGefXA61hgl6U0P3IfwqZlEGRZdkbZig3n57AHZgDiwvg==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.3.0.tgz",
+			"integrity": "sha512-ag1vbjsm1A2C/1arRlfCLRapY7L2JKsQgASvaFyTXFyfqf6wjVSfO3PhJ/KfkyntmwlMXe3sUjMkZKeD89qu8Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"mongodb-memory-server-core": "9.2.0",
+				"mongodb-memory-server-core": "9.3.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4936,9 +4936,9 @@
 			}
 		},
 		"node_modules/mongodb-memory-server-core": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.2.0.tgz",
-			"integrity": "sha512-9SWZEy+dGj5Fvm5RY/mtqHZKS64o4heDwReD4SsfR7+uNgtYo+JN41kPCcJeIH3aJf04j25i5Dia2s52KmsMPA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.3.0.tgz",
+			"integrity": "sha512-8okAtOGWqSG37K7/TrvTfn43ORMh9LssIvd30XjHxvjWK7utmSTXr69XAhYvsDrHDwv7L23Ii6NJ4zMPpiFKuw==",
 			"dev": true,
 			"dependencies": {
 				"async-mutex": "^0.4.0",
@@ -4949,7 +4949,7 @@
 				"https-proxy-agent": "^7.0.4",
 				"mongodb": "^5.9.1",
 				"new-find-package-json": "^2.0.0",
-				"semver": "^7.6.0",
+				"semver": "^7.6.2",
 				"tar-stream": "^3.1.7",
 				"tslib": "^2.6.2",
 				"yauzl": "^3.1.3"
@@ -5666,9 +5666,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
-			"integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
+			"integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "1.0.5"
@@ -5681,22 +5681,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.17.2",
-				"@rollup/rollup-android-arm64": "4.17.2",
-				"@rollup/rollup-darwin-arm64": "4.17.2",
-				"@rollup/rollup-darwin-x64": "4.17.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.17.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.17.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.17.2",
-				"@rollup/rollup-linux-arm64-musl": "4.17.2",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.17.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.17.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.17.2",
-				"@rollup/rollup-linux-x64-gnu": "4.17.2",
-				"@rollup/rollup-linux-x64-musl": "4.17.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.17.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.17.2",
-				"@rollup/rollup-win32-x64-msvc": "4.17.2",
+				"@rollup/rollup-android-arm-eabi": "4.18.0",
+				"@rollup/rollup-android-arm64": "4.18.0",
+				"@rollup/rollup-darwin-arm64": "4.18.0",
+				"@rollup/rollup-darwin-x64": "4.18.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.18.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.18.0",
+				"@rollup/rollup-linux-arm64-musl": "4.18.0",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.18.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.18.0",
+				"@rollup/rollup-linux-x64-gnu": "4.18.0",
+				"@rollup/rollup-linux-x64-musl": "4.18.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.18.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.18.0",
+				"@rollup/rollup-win32-x64-msvc": "4.18.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -5929,13 +5929,14 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-			"integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+			"integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
 			"dev": true,
 			"dependencies": {
-				"fast-fifo": "^1.1.0",
-				"queue-tick": "^1.0.1"
+				"fast-fifo": "^1.3.2",
+				"queue-tick": "^1.0.1",
+				"text-decoder": "^1.1.0"
 			},
 			"optionalDependencies": {
 				"bare-events": "^2.2.0"
@@ -6118,6 +6119,15 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.0.tgz",
+			"integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
+			"dev": true,
+			"dependencies": {
+				"b4a": "^1.6.4"
 			}
 		},
 		"node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "y-mongodb-provider",
-	"version": "0.1.10",
+	"version": "0.2.0",
 	"description": "MongoDB database adapter for Yjs",
 	"type": "module",
 	"main": "./dist/y-mongodb.cjs",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"dist": "rollup -c && tsc",
 		"clean": "rm -rf dist",
 		"test": "npm run dist && jest",
-		"lint": "npx eslint ./src/*",
+		"lint": "npx eslint ./src/* && npx tsc",
 		"build": "npm run dist"
 	},
 	"repository": {
@@ -43,7 +43,6 @@
 		"eslint": "^8.57.0",
 		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-config-prettier": "^9.1.0",
-		"eslint-plugin-import": "^2.29.1",
 		"eslint-plugin-prettier": "^5.1.3",
 		"jest": "^29.7.0",
 		"mongodb-memory-server": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"dist": "rollup -c && tsc",
 		"clean": "rm -rf dist",
 		"test": "npm run dist && jest",
-		"lint": "npx eslint .",
+		"lint": "npx eslint ./src/*",
 		"build": "npm run dist"
 	},
 	"repository": {
@@ -32,22 +32,22 @@
 	},
 	"dependencies": {
 		"lib0": "^0.2.94",
-		"mongodb": "^6.6.2"
+		"mongodb": "^6.7.0"
 	},
 	"peerDependencies": {
-		"yjs": "^13.6.8"
+		"yjs": "^13.6.15"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.5.12",
-		"@types/node": "^20.12.12",
+		"@types/node": "^20.14.2",
 		"eslint": "^8.57.0",
 		"eslint-config-airbnb-base": "^15.0.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-import": "^2.29.1",
 		"eslint-plugin-prettier": "^5.1.3",
 		"jest": "^29.7.0",
-		"mongodb-memory-server": "^9.2.0",
-		"rollup": "^4.17.2",
+		"mongodb-memory-server": "^9.3.0",
+		"rollup": "^4.18.0",
 		"typescript": "^5.4.5",
 		"yjs": "^13.6.15"
 	},
@@ -59,6 +59,8 @@
 	"keywords": [
 		"Yjs",
 		"MongoDB",
+		"database",
+		"adapter",
 		"shared editing",
 		"collaboration",
 		"offline",

--- a/src/utils.js
+++ b/src/utils.js
@@ -234,7 +234,7 @@ export const mergeUpdates = (updates) => {
 };
 
 /**
- * @param {Uint8Array} buf TODO
+ * @param {import("mongodb").Binary} buf
  * @return {{ sv: Uint8Array, clock: number }}
  */
 export const decodeMongodbStateVector = (buf) => {

--- a/src/y-mongodb.js
+++ b/src/y-mongodb.js
@@ -257,7 +257,6 @@ export class MongodbPersistence {
 	 * !Note: The state vectors might be outdated if the associated document
 	 * is not yet flushed. So use with caution.
 	 * @return {Promise<{ name: string, sv: Uint8Array, clock: number }[]>}
-	 * @todo may not work?
 	 */
 	getAllDocStateVectors() {
 		return this._transact('global', async (db) => {

--- a/src/y-mongodb.js
+++ b/src/y-mongodb.js
@@ -54,7 +54,7 @@ export class MongodbPersistence {
 		 *
 		 * @template T
 		 *
-		 * @param {function(any):Promise<T>} f A transaction that receives the db object
+		 * @param {function(MongoAdapter):Promise<T>} f A transaction that receives the db object
 		 * @return {Promise<T>}
 		 */
 		this._transact = (docName, f) => {
@@ -104,7 +104,6 @@ export class MongodbPersistence {
 			ydoc.transact(() => {
 				for (let i = 0; i < updates.length; i++) {
 					Y.applyUpdate(ydoc, updates[i]);
-					updates[i] = null;
 				}
 			});
 			if (updates.length > this.flushSize) {
@@ -172,7 +171,7 @@ export class MongodbPersistence {
 	clearDocument(docName) {
 		return this._transact(docName, async (db) => {
 			if (!this.multipleCollections) {
-				await db.del(U.createDocumentStateVectorKey(docName));
+				await db.delete(U.createDocumentStateVectorKey(docName));
 				await U.clearUpdatesRange(db, docName, 0, binary.BITS32);
 			} else {
 				await db.dropCollection(docName);
@@ -208,7 +207,7 @@ export class MongodbPersistence {
 	 */
 	getMeta(docName, metaKey) {
 		return this._transact(docName, async (db) => {
-			const res = await db.get({
+			const res = await db.findOne({
 				...U.createDocumentMetaKey(docName, metaKey),
 			});
 			if (!res?.value) {
@@ -227,7 +226,7 @@ export class MongodbPersistence {
 	 */
 	delMeta(docName, metaKey) {
 		return this._transact(docName, (db) =>
-			db.del({
+			db.delete({
 				...U.createDocumentMetaKey(docName, metaKey),
 			}),
 		);


### PR DESCRIPTION
This PR significantly enhances the JSDocs for improved type-checking. 

Additionally, several functions in the `mongo-adapter` have been renamed (and rewritten) for better structure. Specifically, `get` and `readAsCursor` have been replaced with `findOne` and `find` respectively, and `del` has been renamed to `delete`. 

Dependencies have also been updated.

Reference: https://github.com/MaxNoetzold/y-mongodb-provider/pull/20#issuecomment-2154608392