### PR TITLE
New mongo adapter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,29 +85,31 @@ server.listen(port, () => {
 
 ## API
 
-### `persistence = MongodbPersistence(connectionLink: string, options: object)`
+### `persistence = MongodbPersistence(connectionObj: string|{ client: MongoClient, db: Db }, options: object)`
 
 Create a y-mongodb-provider persistence instance.
 
 ```js
 import { MongodbPersistence } from 'y-mongodb-provider';
 
-const persistence = new MongodbPersistence('connectionString', {
+const persistence = new MongodbPersistence(connectionObj, {
 	collectionName,
 	flushSize,
 	multipleCollections,
 });
 ```
 
+`connectionObj` can be a connection string or an object with a client and db property. If you pass a connection string, the client and db will be created for you. [It is recommended to use the object form if you use the same client on other parts of your application as well](https://www.mongodb.com/docs/manual/administration/connection-pool-overview/#create-and-use-a-connection-pool).
+
 Options:
 
-- collectionName
+- `collectionName`
   - Name of the collection where all documents are stored
   - Default: `"yjs-writings"`
-- flushSize
+- `flushSize`
   - The number of transactions needed until they are merged automatically into one document
   - Default: `400`
-- multipleCollections
+- `multipleCollections`
   - When set to true, each document gets an own collection (instead of all documents stored in the same one)
   - When set to true, the option collectionName gets ignored.
   - Default: `false`

--- a/src/mongo-adapter.js
+++ b/src/mongo-adapter.js
@@ -1,21 +1,15 @@
 import { MongoClient } from 'mongodb';
 
 /**
- * Parse a MongoDB connection string and return the database name
- * and the connection string without the database name.
+ * Parse a MongoDB connection string and return the database name.
  *
  * @param {string} connectionString
- * @returns {{ database: string, linkWithoutDatabase: string }}
+ * @returns {string}
  */
-function parseMongoDBConnectionString(connectionString) {
+function getMongoDbDatabaseName(connectionString) {
 	const url = new URL(connectionString);
 	const database = url.pathname.slice(1);
-	url.pathname = '/';
-
-	return {
-		database,
-		linkWithoutDatabase: url.toString(),
-	};
+	return database;
 }
 
 export class MongoAdapter {
@@ -31,19 +25,17 @@ export class MongoAdapter {
 	constructor(connectionString, { collection, multipleCollections }) {
 		this.collection = collection;
 		this.multipleCollections = multipleCollections;
-		const connectionParams = parseMongoDBConnectionString(connectionString);
-		this.mongoUrl = connectionParams.linkWithoutDatabase;
-		this.databaseName = connectionParams.database;
-		this.client = new MongoClient(this.mongoUrl);
+		const databaseName = getMongoDbDatabaseName(connectionString);
 		/*
-			client.connect() is optional since v4.7
+			NOTE: client.connect() is optional since v4.7
 			"However, MongoClient.connect can still be called manually and remains useful for
 			learning about misconfiguration (auth, server not started, connection string correctness)
 			early in your application's startup."
 
 			I will not use it for now, but may change that in the future.
 		*/
-		this.db = this.client.db(this.databaseName);
+		this.client = new MongoClient(connectionString);
+		this.db = this.client.db(databaseName);
 	}
 
 	/**

--- a/src/y-mongodb.js
+++ b/src/y-mongodb.js
@@ -7,7 +7,7 @@ import * as U from './utils.js';
 export class MongodbPersistence {
 	/**
 	 * Create a y-mongodb persistence instance.
-	 * @param {string} location The connection string for the MongoDB instance.
+	 * @param {string|{client: import('mongodb').MongoClient, db: import('mongodb').Db}} connectionObj A MongoDB connection string or an object containing a MongoClient instance (`client`) and a database instance (`db`).
 	 * @param {object} [opts] Additional optional parameters.
 	 * @param {string} [opts.collectionName] Name of the collection where all
 	 * documents are stored. Default: "yjs-writings"
@@ -17,7 +17,7 @@ export class MongodbPersistence {
 	 * @param {number} [opts.flushSize] The number of stored transactions needed until
 	 * they are merged automatically into one Mongodb document. Default: 400
 	 */
-	constructor(location, opts = {}) {
+	constructor(connectionObj, opts = {}) {
 		const { collectionName = 'yjs-writings', multipleCollections = false, flushSize = 400 } = opts;
 		if (typeof collectionName !== 'string' || !collectionName) {
 			throw new Error(
@@ -34,7 +34,7 @@ export class MongodbPersistence {
 				'Constructor option "flushSize" is not a valid number. Either dont use this option (default is "400") or use a valid number larger than 0! Take a look into the Readme for more information: https://github.com/MaxNoetzold/y-mongodb-provider#persistence--mongodbpersistenceconnectionlink-string-options-object',
 			);
 		}
-		const db = new MongoAdapter(location, {
+		const db = new MongoAdapter(connectionObj, {
 			collection: collectionName,
 			multipleCollections,
 		});


### PR DESCRIPTION
Solve [this issue](https://github.com/MaxNoetzold/y-mongodb-provider/issues/22) by
- using the database name when creating Y-MongoDb instance to properly authenticate users for the specified database
- allow to provide an existing MongoClient instance at creation because it is just better and [recommended](https://www.mongodb.com/docs/manual/administration/connection-pool-overview/#create-and-use-a-connection-pool)